### PR TITLE
Fix TaxiListAPIView category filtering

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -74,10 +74,6 @@ class TaxiListAPIView(generics.ListAPIView):
             category = Category.objects.get(id = 3)
 
         if category is not None:
-            
-            print('category is', nira)
-            print('category name is', category.name)
-            return TaxiProfile.objects.filter(category=self.category)
+            return TaxiProfile.objects.filter(category=category)
         else:
-            print('category is none')
             return TaxiProfile.objects.all()


### PR DESCRIPTION
## Summary
- update `TaxiListAPIView.get_queryset` to filter with the resolved category instance
- remove debug logging and keep the fallback to return all taxi profiles

## Testing
- python manage.py shell -c "from rest_framework.test import APIRequestFactory" *(fails: missing Django dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ceabcf3a808333b34c7f1c4cd3692c